### PR TITLE
Clarify field naming in reports: update comments and docstrings to re…

### DIFF
--- a/pregdos/results.py
+++ b/pregdos/results.py
@@ -83,9 +83,10 @@ _STANDARD_DEVIATION = "Standard_Deviation"
 # index, so `topas_field01_neutron_Fetus_1.csv` is the same scorer, run again.
 _INCREMENT_RE = re.compile(r"^(?P<stem>.+?)_(?P<index>\d+)$")
 
-# dicomexport names its output `<base>_field<NN>.txt`, where NN is the DICOM **BeamNumber**
-# -- not the beam's position in the plan.  So the number in the filename maps straight onto
-# the RTPLAN, and the two can never drift apart.
+# dicomexport names its output `<base>_field<NN>.txt`, where NN is the field's **1-based
+# ordinal position** in the plan (`i + 1` over the beam sequence) -- NOT the DICOM
+# BeamNumber, which can be anything (e.g. 2, 4, 5, 6).  `beam_names()` is keyed the same way
+# so the number in the filename lines up with the name, and the two never drift apart.
 _FIELD_NUMBER_RE = re.compile(r"_field(?P<number>\d+)\.txt$")
 
 
@@ -153,7 +154,9 @@ class ScorerResult:
 
     @property
     def field_number(self) -> Optional[int]:
-        """DICOM BeamNumber of the field that produced this scorer, from the TOPAS input name."""
+        """1-based ordinal position of the field that produced this scorer, from the TOPAS
+        input name (dicomexport's `_field<NN>`).  This is the plan-order index, not the DICOM
+        BeamNumber."""
         if (m := _FIELD_NUMBER_RE.search(self.parameter_file)):
             return int(m.group("number"))
         return None
@@ -366,15 +369,21 @@ def parse_scorer_csv(path: str | Path) -> ScorerResult:
 
 
 def beam_names(rtplan_path: Optional[str | Path]) -> Dict[int, str]:
-    """Map DICOM ``BeamNumber`` to ``BeamName`` from an RTPLAN.
+    """Map a field's **1-based ordinal position** in the plan to its ``BeamName``.
 
     Clinicians identify a field by its name ("RPO", "Field 2"), not by the order it happens
-    to appear in the plan -- and the two need not agree.  dicomexport encodes the BeamNumber
-    in the TOPAS filename, so the lookup is exact.
+    to appear in the plan.  dicomexport numbers its ``_field<NN>`` outputs by the field's
+    ordinal position in the beam sequence (``i + 1``), *not* by the DICOM ``BeamNumber`` --
+    which can be arbitrary (e.g. 2, 4, 5, 6).  We key the names the same way so the filename
+    ordinal lines up with the name; keying by ``BeamNumber`` would misalign every field whose
+    number is not exactly its position (issue #69).  This matches ``rtdose``, which already
+    indexes the plan's beams by ``beams[field_number - 1]``.
 
     Proton plans are *RT Ion Plan* and use ``IonBeamSequence``; photon plans use
-    ``BeamSequence``.  Returns an empty mapping when the plan is missing or unreadable, so a
-    results page still renders with bare field numbers.
+    ``BeamSequence`` -- the two are mutually exclusive, and dicomexport only ever reads
+    ``IonBeamSequence``, so we take a single sequence (ion preferred) rather than merging
+    both (which would let ordinals collide).  Returns an empty mapping when the plan is
+    missing or unreadable, so a results page still renders with bare field numbers.
     """
     if rtplan_path is None:
         return {}
@@ -385,13 +394,12 @@ def beam_names(rtplan_path: Optional[str | Path]) -> Dict[int, str]:
     except Exception:  # noqa: BLE001 - a bad RTPLAN must not break the results page
         return {}
 
+    seq = getattr(ds, "IonBeamSequence", None) or getattr(ds, "BeamSequence", None) or []
     names: Dict[int, str] = {}
-    for attr in ("IonBeamSequence", "BeamSequence"):
-        for beam in getattr(ds, attr, []) or []:
-            number = getattr(beam, "BeamNumber", None)
-            name = getattr(beam, "BeamName", None) or getattr(beam, "BeamDescription", None)
-            if number is not None and name:
-                names[int(number)] = str(name).strip()
+    for idx, beam in enumerate(seq, start=1):
+        name = getattr(beam, "BeamName", None) or getattr(beam, "BeamDescription", None)
+        if name:
+            names[idx] = str(name).strip()
     return names
 
 

--- a/pregdos/webserver.py
+++ b/pregdos/webserver.py
@@ -792,9 +792,9 @@ def _result_rows(run_dir: Path, study: str):
     metrics, metric_warnings = structure_metrics.ensure_metrics(run_dir)
     warnings.extend(metric_warnings)
 
-    # Field names come from the study's RTPLAN.  A field is identified by its DICOM
-    # BeamNumber, which need not match its position in the plan -- so show the name a
-    # clinician would recognise, not just an index.
+    # Field names come from the study's RTPLAN, keyed by the field's ordinal position in the
+    # plan (the same `_field<NN>` numbering dicomexport writes) -- so show the name a
+    # clinician would recognise next to each field, not just an index.
     plan_fractions = None
     try:
         rtplan = studies.find_rtplan(studies_root(), study)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -107,7 +107,7 @@ def test_structure_name_ending_in_a_number_is_not_an_increment(tmp_path):
 # --- field number and beam name ---
 
 def test_field_number_comes_from_the_parameter_file():
-    """dicomexport names its output by DICOM BeamNumber, so the filename maps onto the plan."""
+    """dicomexport names its output by the field's 1-based ordinal position in the plan."""
     assert parse_scorer_csv(NEUTRON).field_number == 1
 
 
@@ -156,21 +156,25 @@ def _rtplan(tmp_path, beams, sequence="IonBeamSequence", fractions=None):
 
 
 def test_beam_names_from_ion_plan(tmp_path):
-    """Proton plans are RT Ion Plan and use IonBeamSequence."""
+    """Proton plans are RT Ion Plan and use IonBeamSequence; names key by ordinal position."""
     path = _rtplan(tmp_path, [(1, "Field 1"), (2, "RPO"), (3, "LAO")])
     assert results.beam_names(path) == {1: "Field 1", 2: "RPO", 3: "LAO"}
 
 
 def test_beam_names_from_photon_plan(tmp_path):
+    """A single photon beam is the first (ordinal 1) field, whatever its BeamNumber."""
     path = _rtplan(tmp_path, [(7, "AP")], sequence="BeamSequence")
-    assert results.beam_names(path) == {7: "AP"}
+    assert results.beam_names(path) == {1: "AP"}
 
 
-def test_beam_numbers_need_not_match_plan_order(tmp_path):
-    """The whole point of the lookup: beam 2 may be listed first, or numbered arbitrarily."""
-    path = _rtplan(tmp_path, [(5, "Posterior"), (2, "Anterior")])
-    names = results.beam_names(path)
-    assert names[5] == "Posterior" and names[2] == "Anterior"
+def test_beam_names_key_by_plan_order_not_beam_number(tmp_path):
+    """Names follow the field's ordinal position, not its DICOM BeamNumber (issue #69).
+
+    dicomexport numbers `_field<NN>` by position (i + 1), so with the real study's shape --
+    BeamNumbers 2, 4, 5, 6 -- the names must land on ordinals 1..4, not on 2/4/5/6.
+    """
+    path = _rtplan(tmp_path, [(2, "A"), (4, "B"), (5, "C"), (6, "D")])
+    assert results.beam_names(path) == {1: "A", 2: "B", 3: "C", 4: "D"}
 
 
 def test_beam_names_missing_plan_is_empty(tmp_path):


### PR DESCRIPTION
…flect that field names are keyed by their 1-based ordinal position in the plan, not by DICOM BeamNumber. Adjust tests to ensure consistency with this logic.